### PR TITLE
fix 'Possible EventEmitter memory leak detected'

### DIFF
--- a/lib/mimovie.js
+++ b/lib/mimovie.js
@@ -1,8 +1,9 @@
 var	child = require("child_process"),
-	split = require("split");
+	split = require("split"),
+	listener;
 
 module.exports = function(input, cb){
-	var 
+	var
 		rv=[],
 		chd,
 		args=[];
@@ -59,7 +60,9 @@ module.exports = function(input, cb){
 	}
 
 	// Terminate mediainfo on exit
-	process.on('exit', cliexit);
+	if(!listener) {
+		listener = process.on('exit', cliexit);
+  }
 
 };
 


### PR DESCRIPTION
Using this package in parallel with many files (11+) causes the error.
```js
for(const path of arrayOfAtLeast11Paths) {
  miMovie(path, (err, data) => {
    console.log(data)
  })
}
```